### PR TITLE
[feature] add API account util

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pip install -r requirements.txt
   - This wrapper supports automatically breaking up large geometries into smaller geometries behind the scenes
 
 # Usage
-### CLI
+### Imagery CLI
 ```
 > python -m imagery.query
 usage: query.py [-h] -i INPUT_FILE [-s START_DAY] [-e END_DAY] [-L] [-x] [-d MAX_DIST] [-l MAX_LAG] [-z MAX_ANGLE] -o OUTPUT_DIR [-g] [-w WIDTH] [-M] [-I CUSTOM_ID_FIELD]
@@ -82,4 +82,28 @@ options:
   -I CUSTOM_ID_FIELD, --custom_id_field CUSTOM_ID_FIELD
   -S CUSTOM_MIN_DATE_FIELD, --custom_min_date_field CUSTOM_MIN_DATE_FIELD
   -q, --quiet
+```
+
+
+### Querying API Usage
+```
+usage: info.py [-h] -a AUTHORIZATION [-b] [-l LIMIT] [-t] [-v]
+
+options:
+  -h, --help            show this help message and exit
+  -a AUTHORIZATION, --authorization AUTHORIZATION
+  -b, --balance
+  -l LIMIT, --limit LIMIT
+  -t, --history
+  -v, --verbose
+```
+
+### Querying Remaining API Credit Balance
+``` 
+python -m account.info -ba <your encoded key string>
+```
+
+### Querying API Transaction history (default limit of 25)
+``` 
+python -m account.info -ta <your encoded key string>
 ```

--- a/account/info.py
+++ b/account/info.py
@@ -1,0 +1,77 @@
+import argparse
+import json
+import requests
+
+API_URL_BALANCE = 'https://hivemapper.com/api/developer/balance'
+API_URL_HISTORY = 'https://hivemapper.com/api/developer/history'
+
+DEFAULT_LIMIT = 25
+DEFAULT_SKIP = 0
+
+def headers(auth):
+  return {
+    "content-type": "application/json",
+    "authorization": f'Basic {auth}',
+  }
+
+def display_balance(auth):
+  with requests.get(API_URL_BALANCE, headers=headers(auth)) as r:
+    r.raise_for_status()
+    resp = r.json()
+    balance = resp['balance']
+    print(f'Remaining API credits: {balance}')
+
+def format_transaction(transaction, verbose = False):
+  area = transaction['area']
+  timestamp = transaction['timestamp']
+  credits = transaction['credits']
+  payload = transaction['payload']
+  weeks = transaction['weeks']
+
+  lines = [
+    f'> {timestamp}',
+    f'   credits: {credits}'
+  ]
+
+  if verbose:
+    lines += [
+      f'   area: {area:.2f} m^2,',
+      f'   weeks: {", ".join(weeks)}',
+      json.dumps(payload, indent=2),
+    ]
+
+  return  '\n'.join(lines)
+
+def display_history(auth, limit, verbose = False):
+  i = 0
+  while i < limit:
+    lim = min(limit, DEFAULT_LIMIT)
+    url = f'{API_URL_HISTORY}?limit={lim}&skip={i}'
+    with requests.get(url, headers=headers(auth)) as r:
+      r.raise_for_status()
+      resp = r.json()
+      history = resp['history']
+      if not history:
+        return
+
+      for transaction in history:
+        print(format_transaction(transaction, verbose))
+
+    i += lim
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-a', '--authorization', type=str, required=True)
+  parser.add_argument('-b', '--balance', action='store_true')
+  parser.add_argument('-l', '--limit', type=int, default=DEFAULT_LIMIT)
+  parser.add_argument('-t', '--history', action='store_true')
+  parser.add_argument('-v', '--verbose', action='store_true')
+
+  args = parser.parse_args()
+  auth = args.authorization
+
+  if args.balance:
+    display_balance(auth)
+
+  if args.history:
+    display_history(auth, args.limit, args.verbose)


### PR DESCRIPTION
### Querying API Usage
```
usage: info.py [-h] -a AUTHORIZATION [-b] [-l LIMIT] [-t] [-v]

options:
  -h, --help            show this help message and exit
  -a AUTHORIZATION, --authorization AUTHORIZATION
  -b, --balance
  -l LIMIT, --limit LIMIT
  -t, --history
  -v, --verbose
```

### Querying Remaining API Credit Balance
``` 
python -m account.info -ba <your encoded key string>
```

### Querying API Transaction history (default limit of 25)
``` 
python -m account.info -ta <your encoded key string>
```